### PR TITLE
added auto exposure parameters, tested on husky

### DIFF
--- a/include/ximea_camera/ximea_driver.h
+++ b/include/ximea_camera/ximea_driver.h
@@ -78,7 +78,7 @@ protected:
   int bandwidth_;
   int exposure_time_;
   int auto_exposure_;
-  float auto_exposure_limit_;
+  int auto_exposure_limit_;
   int auto_gain_limit_;
   float auto_exposure_priority_;
   bool binning_enabled_;

--- a/include/ximea_camera/ximea_driver.h
+++ b/include/ximea_camera/ximea_driver.h
@@ -53,6 +53,10 @@ public:
   virtual void setImageDataFormat(std::string s);  // this is virtual because the ros class needs to do a bit more work to publish the right image
   void setROI(int rect_left, int rect_top, int rect_width, int rect_height);
   void setExposure(int time);
+  void setAutoExposure(int auto_exposure);
+  void setAutoExposureLimit(int ae_limit);
+  void setAutoGainLimit(int ag_limit);
+  void setAutoExposurePriority(float exp_priority);
   bool hasValidHandle()
   {
     return xiH_ == NULL ? false : true;
@@ -73,7 +77,10 @@ protected:
   int frame_rate_;
   int bandwidth_;
   int exposure_time_;
-  bool auto_exposure_;
+  int auto_exposure_;
+  float auto_exposure_limit_;
+  int auto_gain_limit_;
+  float auto_exposure_priority_;
   bool binning_enabled_;
   int downsample_factor_;
   int rect_left_;

--- a/src/ximea_driver.cpp
+++ b/src/ximea_driver.cpp
@@ -68,12 +68,13 @@ void ximea_driver::errorHandling(XI_RETURN ret, std::string message)
 void ximea_driver::applyParameters()
 {
   setImageDataFormat(image_data_format_);
-  setExposure(exposure_time_);
-  if (auto_exposure_ == 1){
+  if (0 == auto_exposure_) {
+      setExposure(exposure_time_);
+  } else {
       setAutoExposure(auto_exposure_);
       setAutoExposureLimit(auto_exposure_limit_);
       setAutoGainLimit(auto_gain_limit_);
-      setAutoExposurePriority(auto_exposure_limit_);
+      setAutoExposurePriority(auto_exposure_priority_);
   }
   setROI(rect_left_, rect_top_, rect_width_, rect_height_);
 }
@@ -261,12 +262,11 @@ void ximea_driver::setAutoExposure(int auto_exposure)
   {
     // auto_exposureme_ = time;
   }
-  xiSetParamInt(xiH_, XI_PRM_EXP_PRIORITY, 0.5);
 }
 
 void ximea_driver::setAutoExposureLimit(int ae_limit)
 {
-  XI_RETURN stat = xiSetParamInt(xiH_, XI_PRM_AE_MAX_LIMIT, ae_limit);
+  XI_RETURN stat = xiSetParamFloat(xiH_, XI_PRM_AE_MAX_LIMIT, ae_limit);
   errorHandling(stat, "xiOSetParamInt (AutoExposure Limit Time)");
   if (!stat)
   {
@@ -277,7 +277,7 @@ void ximea_driver::setAutoExposureLimit(int ae_limit)
 void ximea_driver::setAutoGainLimit(int ag_limit)
 {
   XI_RETURN stat = xiSetParamInt(xiH_, XI_PRM_AG_MAX_LIMIT, ag_limit);
-  errorHandling(stat, "xiOSetParamInt (AutoExposure Limit Time)");
+  errorHandling(stat, "xiOSetParamInt (AutoExposure Limit GAIN)");
   if (!stat)
   {
     // auto_exposureme_ = time;
@@ -288,7 +288,7 @@ void ximea_driver::setAutoGainLimit(int ag_limit)
 void ximea_driver::setAutoExposurePriority(float exp_priority)
 {
   XI_RETURN stat = xiSetParamFloat(xiH_, XI_PRM_EXP_PRIORITY, exp_priority);
-  errorHandling(stat, "xiOSetParamInt (AutoExposure Limit Time)");
+  errorHandling(stat, "xiOSetParamInt (AutoExposure Priority)");
   if (!stat)
   {
     // auto_exposureme_ = time;
@@ -373,7 +373,7 @@ int ximea_driver::readParamsFromFile(std::string file_name)
 
   try
   {
-    auto_exposure_priority_ = doc["auto_exposure_priority"].as<int>();
+    auto_exposure_priority_ = doc["auto_exposure_priority"].as<float>();
   }
   catch (std::runtime_error) {}
 

--- a/src/ximea_driver.cpp
+++ b/src/ximea_driver.cpp
@@ -29,7 +29,11 @@ void ximea_driver::assignDefaultValues()
   bandwidth_safety_margin_ = 30;
   binning_enabled_ = false;
   downsample_factor_ = false;
-  auto_exposure_ = false;
+  auto_exposure_ = 0;
+  auto_exposure_limit_ = 500000;
+  auto_gain_limit_ = 2;
+  auto_exposure_priority_ = 0.8;
+
   exposure_time_ = 1000;
   image_data_format_ = "XI_MONO8";
   rect_left_ = 0;
@@ -65,6 +69,12 @@ void ximea_driver::applyParameters()
 {
   setImageDataFormat(image_data_format_);
   setExposure(exposure_time_);
+  if (auto_exposure_ == 1){
+      setAutoExposure(auto_exposure_);
+      setAutoExposureLimit(auto_exposure_limit_);
+      setAutoGainLimit(auto_gain_limit_);
+      setAutoExposurePriority(auto_exposure_limit_);
+  }
   setROI(rect_left_, rect_top_, rect_width_, rect_height_);
 }
 
@@ -243,6 +253,48 @@ void ximea_driver::setExposure(int time)
   }
 }
 
+void ximea_driver::setAutoExposure(int auto_exposure)
+{
+  XI_RETURN stat = xiSetParamInt(xiH_, XI_PRM_AEAG, auto_exposure);
+  errorHandling(stat, "xiOSetParamInt (AutoExposure Time)");
+  if (!stat)
+  {
+    // auto_exposureme_ = time;
+  }
+  xiSetParamInt(xiH_, XI_PRM_EXP_PRIORITY, 0.5);
+}
+
+void ximea_driver::setAutoExposureLimit(int ae_limit)
+{
+  XI_RETURN stat = xiSetParamInt(xiH_, XI_PRM_AE_MAX_LIMIT, ae_limit);
+  errorHandling(stat, "xiOSetParamInt (AutoExposure Limit Time)");
+  if (!stat)
+  {
+    // auto_exposureme_ = time;
+  }
+}
+
+void ximea_driver::setAutoGainLimit(int ag_limit)
+{
+  XI_RETURN stat = xiSetParamInt(xiH_, XI_PRM_AG_MAX_LIMIT, ag_limit);
+  errorHandling(stat, "xiOSetParamInt (AutoExposure Limit Time)");
+  if (!stat)
+  {
+    // auto_exposureme_ = time;
+  }
+}
+
+
+void ximea_driver::setAutoExposurePriority(float exp_priority)
+{
+  XI_RETURN stat = xiSetParamFloat(xiH_, XI_PRM_EXP_PRIORITY, exp_priority);
+  errorHandling(stat, "xiOSetParamInt (AutoExposure Limit Time)");
+  if (!stat)
+  {
+    // auto_exposureme_ = time;
+  }
+}
+
 
 int ximea_driver::readParamsFromFile(std::string file_name)
 {
@@ -303,7 +355,25 @@ int ximea_driver::readParamsFromFile(std::string file_name)
 
   try
   {
-    auto_exposure_ = doc["auto_exposure"].as<bool>();
+    auto_exposure_ = doc["auto_exposure"].as<int>();
+  }
+  catch (std::runtime_error) {}
+
+  try
+  {
+    auto_exposure_limit_ = doc["auto_exposure_limit"].as<int>();
+  }
+  catch (std::runtime_error) {}
+
+  try
+  {
+    auto_gain_limit_ = doc["auto_gain_limit"].as<int>();
+  }
+  catch (std::runtime_error) {}
+
+  try
+  {
+    auto_exposure_priority_ = doc["auto_exposure_priority"].as<int>();
   }
   catch (std::runtime_error) {}
 
@@ -396,6 +466,6 @@ void ximea_driver::limitBandwidth(int mbps)
 {
   if (!xiH_) return;
   XI_RETURN stat;
-  stat = xiSetParamInt(xiH_, XI_PRM_LIMIT_BANDWIDTH , mbps);
-  errorHandling(stat, "could not limit bandwidth");
+  // stat = xiSetParamInt(xiH_, XI_PRM_LIMIT_BANDWIDTH , mbps);
+  // errorHandling(stat, "could not limit bandwidth");
 }


### PR DESCRIPTION
Added parameters to allow for auto exposure to be turned on and settings to be changed. 

These include:
Auto gain : limit the max gain (int 0 - 12 db), camera becomes grainy about about a gain of 8
Auto Exposure limit : Limit the max exposure time - (float 0 - 10000000 microseconds) - High values make image brighter but cause blur

Auto Exposure Priority: (float 0 - 1.0) - a value of 0 causes only gain to be changed, 1 causes only exposure to be changed. 
