### PR TITLE
add frame id

### DIFF
--- a/include/ximea_camera/ximea_driver.h
+++ b/include/ximea_camera/ximea_driver.h
@@ -68,6 +68,7 @@ protected:
   // variables for ximea api internals
   std::string cam_name_;
   int serial_no_;
+  std::string frame_id_;
   int cams_on_bus_;
   int bandwidth_safety_margin_;
   int frame_rate_;

--- a/src/ximea_driver.cpp
+++ b/src/ximea_driver.cpp
@@ -42,6 +42,7 @@ void ximea_driver::assignDefaultValues()
   image_.bp_size = 0;
   acquisition_active_ = false;
   image_capture_timeout_ = 1000;
+  frame_id_ = "";
 }
 
 ximea_driver::ximea_driver(std::string file_name)
@@ -268,6 +269,11 @@ int ximea_driver::readParamsFromFile(std::string file_name)
   try
   {
     cam_name_ =  doc["cam_name"].as<std::string>();
+  }
+  catch (std::runtime_error) {}
+  try
+  {
+    frame_id_ =  doc["frame_id"].as<std::string>();
   }
   catch (std::runtime_error) {}
 

--- a/src/ximea_ros_driver.cpp
+++ b/src/ximea_ros_driver.cpp
@@ -66,6 +66,7 @@ void ximea_ros_driver::publishCamInfo(const ros::Time &now)
 {
   ros_image_.header.stamp = now;
   cam_info_ = cam_info_manager_->getCameraInfo();
+  cam_info_.header.frame_id = frame_id_;
   cam_info_pub_.publish(cam_info_);
 }
 


### PR DESCRIPTION
Driver now publishes name of frame id in camera_info as declared in configuration yaml file